### PR TITLE
specify dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,16 @@
     ],
     "homepage": "https://github.com/php-http/throttle-plugin",
     "require": {
-        "php": ">=7.4",
-        "php-http/client-common": ">=1.3",
-        "symfony/rate-limiter": ">=5.2"
+        "php": "^7.4 || ^8.0",
+        "php-http/client-common": "^1.3",
+        "symfony/rate-limiter": "^5.2 || ^6.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.0",
-        "php-http/mock-client": "*",
+        "php-http/mock-client": "^1.5",
         "ramsey/coding-standard": "^2.0",
-        "symfony/phpunit-bridge": ">=6.0"
+        "symfony/phpunit-bridge": "^6.0"
     },
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "nyholm/psr7": "^1.0",
         "php-http/mock-client": "^1.0",
         "ramsey/coding-standard": "^2.0",
-        "phpcsstandards/phpcsextra": "^1.0.0-alpha3@alpha",
+        "phpcsstandards/phpcsextra": "^1.0@alpha",
+        "phpcsstandards/phpcsutils": "^1.0@alpha",
         "symfony/phpunit-bridge": "^6.0"
     },
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "nyholm/psr7": "^1.0",
         "php-http/mock-client": "^1.0",
         "ramsey/coding-standard": "^2.0",
+        "phpcsstandards/phpcsextra": "^1.0.0-alpha3@alpha",
         "symfony/phpunit-bridge": "^6.0"
     },
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "homepage": "https://github.com/php-http/throttle-plugin",
     "require": {
         "php": "^7.4 || ^8.0",
-        "php-http/client-common": "^1.3",
+        "php-http/client-common": "^1.3 || ^2.0",
         "symfony/rate-limiter": "^5.2 || ^6.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.0",
-        "php-http/mock-client": "^1.5",
+        "php-http/mock-client": "^1.0",
         "ramsey/coding-standard": "^2.0",
         "symfony/phpunit-bridge": "^6.0"
     },


### PR DESCRIPTION
i much prefer to be explicit in what we support. the goal of semver is to avoid letting people install incompatible things. we can't know today what PHP 9 or Symfony 7 will do. (I know symfony itself is handling this differently, but strongly disagree ;-) )

what is with the allowed script `"ergebnis/composer-normalize": true`? should we include that in the dev dependencies and CI?