### PR TITLE
Add token price and maxTime parameters

### DIFF
--- a/src/ThrottlePlugin.php
+++ b/src/ThrottlePlugin.php
@@ -6,6 +6,7 @@ namespace Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
 use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
@@ -32,8 +33,8 @@ final class ThrottlePlugin implements Plugin
 
     /**
      * @throws MaxWaitDurationExceededException if $maxTime is set and the process needs to wait longer than its value (in seconds)
-     * @throws ReserveNotSupportedException     if this limiter implementation doesn't support reserving tokens
-     * @throws \InvalidArgumentException        if $tokens is larger than the maximum burst size
+     * @throws ReserveNotSupportedException if this limiter implementation doesn't support reserving tokens
+     * @throws InvalidArgumentException if $tokens is larger than the maximum burst size
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {

--- a/src/ThrottlePlugin.php
+++ b/src/ThrottlePlugin.php
@@ -7,20 +7,37 @@ namespace Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\LimiterInterface;
 
 final class ThrottlePlugin implements Plugin
 {
     private LimiterInterface $rateLimiter;
 
-    public function __construct(LimiterInterface $rateLimiter)
+    private int $tokens;
+
+    private ?float $maxTime;
+
+    /**
+     * @param int $tokens the number of tokens required
+     * @param float|null $maxTime maximum accepted waiting time in seconds
+     */
+    public function __construct(LimiterInterface $rateLimiter, int $tokens = 1, ?float $maxTime = null)
     {
         $this->rateLimiter = $rateLimiter;
+        $this->tokens = $tokens;
+        $this->maxTime = $maxTime;
     }
 
+    /**
+     * @throws MaxWaitDurationExceededException if $maxTime is set and the process needs to wait longer than its value (in seconds)
+     * @throws ReserveNotSupportedException     if this limiter implementation doesn't support reserving tokens
+     * @throws \InvalidArgumentException        if $tokens is larger than the maximum burst size
+     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
-        $this->rateLimiter->reserve()->wait();
+        $this->rateLimiter->reserve($this->tokens, $this->maxTime)->wait();
 
         return $next($request);
     }

--- a/tests/ThrottlePluginTest.php
+++ b/tests/ThrottlePluginTest.php
@@ -94,7 +94,7 @@ class ThrottlePluginTest extends TestCase
 
         $this->expectException(MaxWaitDurationExceededException::class);
         $this->expectExceptionMessage('The rate limiter wait time ("3" seconds) is longer than the provided maximum time ("1" seconds).');
-        
+
         $time = time();
         $this->client->sendRequest(new Request('GET', ''));
         $this->client->sendRequest(new Request('GET', ''));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| License         | MIT


#### What's in this PR?

This PR introduces two new parameters to the existing functionality:

    $tokens: an integer representing the number of tokens required.
    $maxTime: an optional float representing the maximum accepted waiting time in seconds.

#### Why?

This PR addresses the need to manage the number of tokens and the maximum waiting time in the application, providing more control over these parameters and enhancing the flexibility of the system.
And most importantly, it allows setting a maximum waiting time for blocking, making it easy to fall back when the limit is reached.